### PR TITLE
Abstract out semantic language tools + experiment with COC

### DIFF
--- a/.vim/autoload/dhleong.vim
+++ b/.vim/autoload/dhleong.vim
@@ -1,6 +1,10 @@
 " Lazy-loaded functions for use in various .vimrc mappings, etc.
 "
 
+func! dhleong#completer()
+    return dhleong#completer#Create()
+endfunc
+
 function! dhleong#GotoInNewTab(...)
     let l:method = 'GoTo'
     if a:0

--- a/.vim/autoload/dhleong.vim
+++ b/.vim/autoload/dhleong.vim
@@ -11,16 +11,10 @@ function! dhleong#GotoInNewTab(...)
         let l:method = a:1
     endif
 
-    if a:0 > 1
-        let l:cmd = a:2
-    else
-        let l:cmd = ':YcmCompleter ' . l:method
-    endif
-
     let l:c = getpos('.')
     tabe %
     call cursor(l:c[1], l:c[2])
-    exe l:cmd
+    call dhleong#completer().Navigate(l:method)
 endfunction
 
 function! dhleong#OpenPlugRepo()

--- a/.vim/autoload/dhleong/completer.vim
+++ b/.vim/autoload/dhleong/completer.vim
@@ -1,0 +1,4 @@
+func! dhleong#completer#Create()
+    let requested = g:dhleong_completer
+    return call('dhleong#completer#' . requested . '#Create', [])
+endfunc

--- a/.vim/autoload/dhleong/completer/coc.vim
+++ b/.vim/autoload/dhleong/completer/coc.vim
@@ -20,3 +20,12 @@ endfunc
 func! s:completer.RenameWord() abort
     call CocActionAsync('rename')
 endfunc
+
+func! s:completer.MapNavigation() abort
+    " FIXME: new tab handling
+    nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab("GoToDefinition")<cr>
+    nmap <silent><buffer> gd <Plug>(coc-definition)
+    nmap <silent><buffer> <leader>js <Plug>(coc-references)
+    nnoremap <buffer> <leader>jr :call dhleong#refactor#Rename()<cr>
+    nnoremap <silent><buffer> K :call CocActionAsync('doHover')<cr>
+endfunc

--- a/.vim/autoload/dhleong/completer/coc.vim
+++ b/.vim/autoload/dhleong/completer/coc.vim
@@ -16,3 +16,7 @@ endfunc
 func! s:completer.PerformQuickFix() abort
     call CocActionAsync('doQuickfix')
 endfunc
+
+func! s:completer.RenameWord() abort
+    call CocActionAsync('rename')
+endfunc

--- a/.vim/autoload/dhleong/completer/coc.vim
+++ b/.vim/autoload/dhleong/completer/coc.vim
@@ -21,11 +21,14 @@ func! s:completer.RenameWord() abort
     call CocActionAsync('rename')
 endfunc
 
-func! s:completer.MapNavigation() abort
-    " FIXME: new tab handling
-    nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab("GoToDefinition")<cr>
-    nmap <silent><buffer> gd <Plug>(coc-definition)
-    nmap <silent><buffer> <leader>js <Plug>(coc-references)
-    nnoremap <buffer> <leader>jr :call dhleong#refactor#Rename()<cr>
+func! s:completer.Navigate(method) abort
+    " Can we distinguish between GoTo and GoToDefinition?
+    call CocActionAsync('jumpDefinition')
+endfunc
+
+func! s:completer.MapNavigation(...) abort
+    call dhleong#completer#shared#MapSharedNavigation(get(a:, 1, ''))
+
     nnoremap <silent><buffer> K :call CocActionAsync('doHover')<cr>
+    nmap <silent><buffer> <leader>js <Plug>(coc-references)
 endfunc

--- a/.vim/autoload/dhleong/completer/coc.vim
+++ b/.vim/autoload/dhleong/completer/coc.vim
@@ -1,0 +1,18 @@
+let s:completer = {'_type': 'coc'}
+
+func! dhleong#completer#coc#Create()
+    return s:completer
+endfunc
+
+func! s:completer.FillLocList() abort
+    call coc#rpc#request('fillDiagnostics', [bufnr('%')])
+endfunc
+
+func! s:completer.HasQuickFixes() abort
+    let fixes = coc#rpc#request('quickfixes', [])
+    return !empty(fixes)
+endfunc
+
+func! s:completer.PerformQuickFix() abort
+    call CocActionAsync('doQuickfix')
+endfunc

--- a/.vim/autoload/dhleong/completer/coc.vim
+++ b/.vim/autoload/dhleong/completer/coc.vim
@@ -32,3 +32,23 @@ func! s:completer.MapNavigation(...) abort
     nnoremap <silent><buffer> K :call CocActionAsync('doHover')<cr>
     nmap <silent><buffer> <leader>js <Plug>(coc-references)
 endfunc
+
+func! s:ConfirmCompletion(key) abort
+    let state = complete_info()
+    let selected = state['selected']
+    if selected == -1
+        return a:key
+    endif
+
+    " NOTE: this does not actually seem to do anything:
+    let item = state['items'][selected]
+    call coc#rpc#notify('CocAutocmd', ['CompleteDone', item])
+
+    return a:key
+endfunc
+
+func! s:completer.HandleConfirmCompletion(keys) abort
+    for key in a:keys
+        exe 'inoremap <buffer><silent><expr> ' . key . ' <SID>ConfirmCompletion("' . key . '")'
+    endfor
+endfunc

--- a/.vim/autoload/dhleong/completer/shared.vim
+++ b/.vim/autoload/dhleong/completer/shared.vim
@@ -1,0 +1,7 @@
+func! dhleong#completer#shared#MapSharedNavigation(method)
+    let method = empty(a:method) ? 'GoToDefinition' : a:method
+    exe 'nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab("' . method . '")<cr>'
+    exe 'nnoremap <buffer> gd :call dhleong#completer().Navigate("' . method . '")<cr>'
+
+    nnoremap <buffer> <leader>jr :call dhleong#refactor#Rename()<cr>
+endfunc

--- a/.vim/autoload/dhleong/completer/ycm.vim
+++ b/.vim/autoload/dhleong/completer/ycm.vim
@@ -1,0 +1,19 @@
+let s:completer = {'_type': 'ycm'}
+
+func! dhleong#completer#ycm#Create()
+    return s:completer
+endfunc
+
+func! s:completer.FillLocList()
+    :YcmForceCompileAndDiagnostics
+    redraw!
+endfunc
+
+func! s:completer.HasQuickFixes() abort
+    let ycmCommands = youcompleteme#SubCommandsComplete('','', 0)
+    return match(ycmCommands, 'FixIt')
+endfunc
+
+func! s:completer.PerformQuickFix() abort
+    :YcmCompleter FixIt
+endfunc

--- a/.vim/autoload/dhleong/completer/ycm.vim
+++ b/.vim/autoload/dhleong/completer/ycm.vim
@@ -11,7 +11,7 @@ endfunc
 
 func! s:completer.HasQuickFixes() abort
     let ycmCommands = youcompleteme#SubCommandsComplete('','', 0)
-    return match(ycmCommands, 'FixIt')
+    return match(ycmCommands, 'FixIt') != -1
 endfunc
 
 func! s:completer.PerformQuickFix() abort

--- a/.vim/autoload/dhleong/completer/ycm.vim
+++ b/.vim/autoload/dhleong/completer/ycm.vim
@@ -17,3 +17,9 @@ endfunc
 func! s:completer.PerformQuickFix() abort
     :YcmCompleter FixIt
 endfunc
+
+func! s:completer.RenameWord() abort
+    " TODO place cursor where it was in the word
+    let word = expand('<cword>')
+    call feedkeys('q:iYcmCompleter RefactorRename ' . word . "\<esc>b", 'n')
+endfunc

--- a/.vim/autoload/dhleong/completer/ycm.vim
+++ b/.vim/autoload/dhleong/completer/ycm.vim
@@ -24,10 +24,13 @@ func! s:completer.RenameWord() abort
     call feedkeys('q:iYcmCompleter RefactorRename ' . word . "\<esc>b", 'n')
 endfunc
 
-func! s:completer.MapNavigation() abort
-    nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab("GoToDefinition")<cr>
-    nnoremap <buffer> gd :YcmCompleter GoToDefinition<cr>
+func! s:completer.Navigate(method) abort
+    exe ':YcmCompleter ' . a:method
+endfunc
+
+func! s:completer.MapNavigation(...) abort
+    call dhleong#completer#shared#MapSharedNavigation(get(a:, 1, ''))
+
     nnoremap <buffer> K :YcmCompleter GetDoc<cr>
-    nnoremap <buffer> <leader>jr :call dhleong#refactor#Rename()<cr>
     nnoremap <buffer> <leader>js :YcmCompleter GoToReferences<cr>
 endfunc

--- a/.vim/autoload/dhleong/completer/ycm.vim
+++ b/.vim/autoload/dhleong/completer/ycm.vim
@@ -34,3 +34,7 @@ func! s:completer.MapNavigation(...) abort
     nnoremap <buffer> K :YcmCompleter GetDoc<cr>
     nnoremap <buffer> <leader>js :YcmCompleter GoToReferences<cr>
 endfunc
+
+func! s:completer.HandleConfirmCompletion(keys) abort
+    " NOP: YCM doesn't do anything with this (I think?)
+endfunc

--- a/.vim/autoload/dhleong/completer/ycm.vim
+++ b/.vim/autoload/dhleong/completer/ycm.vim
@@ -23,3 +23,11 @@ func! s:completer.RenameWord() abort
     let word = expand('<cword>')
     call feedkeys('q:iYcmCompleter RefactorRename ' . word . "\<esc>b", 'n')
 endfunc
+
+func! s:completer.MapNavigation() abort
+    nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab("GoToDefinition")<cr>
+    nnoremap <buffer> gd :YcmCompleter GoToDefinition<cr>
+    nnoremap <buffer> K :YcmCompleter GetDoc<cr>
+    nnoremap <buffer> <leader>jr :call dhleong#refactor#Rename()<cr>
+    nnoremap <buffer> <leader>js :YcmCompleter GoToReferences<cr>
+endfunc

--- a/.vim/autoload/dhleong/fix.vim
+++ b/.vim/autoload/dhleong/fix.vim
@@ -14,8 +14,7 @@ function s:TryFixAle()
 endfunction
 
 function! dhleong#fix#Fix()
-    let ycmCommands = youcompleteme#SubCommandsComplete('','', 0)
-    if ycmCommands == ''
+    if !dhleong#completer().HasQuickFixes()
         " no completer options; clear error output from above
         call s:ClearEcho('')
 
@@ -25,16 +24,13 @@ function! dhleong#fix#Fix()
 
     let before = changenr()
 
-    if match(ycmCommands, 'FixIt') != -1
-        " FixIt supported!
-        YcmCompleter FixIt
-    endif
+    call dhleong#completer().PerformQuickFix()
 
-    let afterYcm = changenr()
-    if afterYcm == before
+    let afterCompleter = changenr()
+    if afterCompleter == before
         " YCM's default message would be nice if we weren't about
         " to also try ALE...
-        call s:ClearEcho("YCM found nothing to fix...")
+        call s:ClearEcho('Completer found nothing to fix...')
     endif
 
     call s:TryFixAle()

--- a/.vim/autoload/dhleong/fix.vim
+++ b/.vim/autoload/dhleong/fix.vim
@@ -28,7 +28,7 @@ function! dhleong#fix#Fix()
 
     let afterCompleter = changenr()
     if afterCompleter == before
-        " YCM's default message would be nice if we weren't about
+        " The completer's default message would be nice if we weren't about
         " to also try ALE...
         call s:ClearEcho('Completer found nothing to fix...')
     endif

--- a/.vim/autoload/dhleong/ft/javascript.vim
+++ b/.vim/autoload/dhleong/ft/javascript.vim
@@ -99,6 +99,7 @@ func! dhleong#ft#javascript#Config()
     " ======= mappings ========================================
 
     call dhleong#completer().MapNavigation()
+    call dhleong#completer().HandleConfirmCompletion(['.', '(', '<space>'])
 
     nnoremap <buffer> <leader>op :exe 'find package.json'<cr>
     nnoremap <buffer> <leader>top :tabe \| exe 'find package.json'<cr>

--- a/.vim/autoload/dhleong/ft/javascript.vim
+++ b/.vim/autoload/dhleong/ft/javascript.vim
@@ -1,9 +1,9 @@
 func! s:CreateTestFilePath()
     let type = expand('%:e')
     let path = expand('%:p')
-    let path = substitute(path, "." . type . "$", "-test." . type, "")
-    let path = substitute(path, "/src/", "/test/", "")
-    let path = substitute(path, "/lib/", "/test/", "")
+    let path = substitute(path, '.' . type . '$', '-test.' . type, '')
+    let path = substitute(path, '/src/', '/test/', '')
+    let path = substitute(path, '/lib/', '/test/', '')
 
     return path
 endfunc
@@ -11,8 +11,8 @@ endfunc
 func! s:FillTestFile(path)
     let path = a:path
     if !filereadable(path)
-        if !isdirectory(expand("%:p:h"))
-            call mkdir(expand("%:p:h"), "p")
+        if !isdirectory(expand('%:p:h'))
+            call mkdir(expand('%:p:h'), 'p')
         endif
 
         let type = expand('%:e')
@@ -25,7 +25,7 @@ func! s:FillTestFile(path)
                         \ '',
                         \ 'chai.should();']
         else
-            let buffer = [];
+            let buffer = []
         endif
 
         call append(0, buffer)
@@ -33,11 +33,11 @@ func! s:FillTestFile(path)
 endfunc
 
 " if guard to protect against E127
-if !exists("*s:CreateJsLikeTestFile")
+if !exists('*s:CreateJsLikeTestFile')
     function! s:CreateJsLikeTestFile()
         let path = s:CreateTestFilePath()
 
-        exe "edit " . path
+        exe 'edit ' . path
         call s:FillTestFile(path)
     endfunction
 endif
@@ -89,8 +89,8 @@ func! dhleong#ft#javascript#Config()
 
         " also, enable prettier auto-format
         let b:ale_fixers = {
-            \ "typescript": ["prettier"],
-            \ "javascript": ["prettier"],
+            \ 'typescript': ['prettier'],
+            \ 'javascript': ['prettier'],
             \ }
         let b:ale_fix_on_save = 1
     endif
@@ -98,11 +98,7 @@ func! dhleong#ft#javascript#Config()
 
     " ======= mappings ========================================
 
-    nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab("GoToDefinition")<cr>
-    nnoremap <buffer> gd :YcmCompleter GoToDefinition<cr>
-    nnoremap <buffer> K :YcmCompleter GetDoc<cr>
-    nnoremap <buffer> <leader>jr :call dhleong#refactor#Rename()<cr>
-    nnoremap <buffer> <leader>js :YcmCompleter GoToReferences<cr>
+    call dhleong#completer().MapNavigation()
 
     nnoremap <buffer> <leader>op :exe 'find package.json'<cr>
     nnoremap <buffer> <leader>top :tabe \| exe 'find package.json'<cr>

--- a/.vim/autoload/dhleong/loclist.vim
+++ b/.vim/autoload/dhleong/loclist.vim
@@ -1,7 +1,7 @@
 
 " all types that should fallback to standard loclist navigation
-" and which rely on YCM's diagnostics instead of ALE
-let s:YcmJumpingTypes = [
+" and which rely on the completer's diagnostics instead of ALE
+let s:AleIgnoringJumpingTypes = [
     \ 'cs', 'cpp',
     \ ]
 
@@ -36,7 +36,7 @@ func! dhleong#loclist#JumpToNextError()
     " make sure diagnostics are up-to-date
     call dhleong#completer().FillLocList()
 
-    if index(s:YcmJumpingTypes, &filetype) != -1
+    if index(s:AleIgnoringJumpingTypes, &filetype) != -1
         call s:FallbackJumpToNextError()
         return
     endif

--- a/.vim/autoload/dhleong/loclist.vim
+++ b/.vim/autoload/dhleong/loclist.vim
@@ -5,7 +5,7 @@ let s:YcmJumpingTypes = [
     \ 'cs', 'cpp',
     \ ]
 
-funct! s:FallbackJumpToNextError()
+func! s:FallbackJumpToNextError()
     try
         lnext
     catch /.*No.more.items$/
@@ -33,10 +33,12 @@ func! dhleong#loclist#JumpToNextError()
         return
     endif
 
+    " make sure diagnostics are up-to-date
     if exists(':YcmForceCompileAndDiagnostics')
-        " make sure diagnostics are up-to-date
         :YcmForceCompileAndDiagnostics
         redraw!
+    elseif exists('*CocAction')
+        call coc#rpc#request('fillDiagnostics', [bufnr('%')])
     endif
 
     if index(s:YcmJumpingTypes, &filetype) != -1
@@ -53,9 +55,7 @@ func! dhleong#loclist#JumpToNextError()
         if l:nearest[0] == line('.')
             echo 'This is the only error!'
         endif
-    elseif len(getloclist(0)) > 0
-        call s:FallbackJumpToNextError()
     else
-        call dhleong#util#EchoBold('No errors :)')
+        call s:FallbackJumpToNextError()
     endif
 endfunc

--- a/.vim/autoload/dhleong/loclist.vim
+++ b/.vim/autoload/dhleong/loclist.vim
@@ -34,12 +34,7 @@ func! dhleong#loclist#JumpToNextError()
     endif
 
     " make sure diagnostics are up-to-date
-    if exists(':YcmForceCompileAndDiagnostics')
-        :YcmForceCompileAndDiagnostics
-        redraw!
-    elseif exists('*CocAction')
-        call coc#rpc#request('fillDiagnostics', [bufnr('%')])
-    endif
+    call dhleong#completer().FillLocList()
 
     if index(s:YcmJumpingTypes, &filetype) != -1
         call s:FallbackJumpToNextError()

--- a/.vim/autoload/dhleong/refactor.vim
+++ b/.vim/autoload/dhleong/refactor.vim
@@ -1,6 +1,4 @@
 
 function! dhleong#refactor#Rename()
-    " TODO place cursor where it was in the word
-    let word = expand('<cword>')
-    call feedkeys('q:iYcmCompleter RefactorRename ' . word . "\<esc>b", 'n')
+    call dhleong#completer().RenameWord()
 endfunction

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,0 +1,4 @@
+{
+    "coc.preferences.formatOnSaveFiletypes": ["python", "rust"],
+    "coc.preferences.promptInput": false
+}

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -3,5 +3,6 @@
     "coc.preferences.promptInput": false,
     "diagnostic.errorSign": "❌",
     "diagnostic.warningSign": "⚠️ ",
-    "suggest.triggerAfterInsertEnter": true
+    "suggest.triggerAfterInsertEnter": true,
+    "javascript.suggestionActions.enabled": false
 }

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,4 +1,7 @@
 {
     "coc.preferences.formatOnSaveFiletypes": ["python", "rust"],
-    "coc.preferences.promptInput": false
+    "coc.preferences.promptInput": false,
+    "diagnostic.errorSign": "❌",
+    "diagnostic.warningSign": "⚠️ ",
+    "suggest.triggerAfterInsertEnter": true
 }

--- a/.vim/ftplugin/elixir.vim
+++ b/.vim/ftplugin/elixir.vim
@@ -12,7 +12,4 @@ let b:ale_fix_on_save = 1
 
 " ======= mappings ========================================
 
-nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab("GoToDefinition")<cr>
-nnoremap <buffer> gd :YcmCompleter GoToDefinition<cr>
-nnoremap <buffer> K :YcmCompleter GetHover<cr>
-nnoremap <buffer> <leader>js :YcmCompleter GoToReferences<cr>
+call dhleong#completer().MapNavigation()

--- a/.vim/ftplugin/go.vim
+++ b/.vim/ftplugin/go.vim
@@ -2,7 +2,7 @@
 if !exists('*s:switchToSourceFolder')
     function! s:switchToSourceFolder(name)
         let targetFolderName = a:name
-        if targetFolderName == '%'
+        if targetFolderName ==# '%'
             let serviceName = expand('%:r')
             let targetFolderName = serviceName
         endif
@@ -18,8 +18,8 @@ setlocal listchars=tab:\ \ ,trail:·
 " auto-continue comments on <cr>
 setlocal formatoptions+=r
 
-nnoremap <buffer> gd :YcmCompleter GoTo<cr>
-nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab('', ':YcmCompleter GoTo')<cr>
+nnoremap <buffer> gd :call dhleong#completer().Navigate('GoTo')<cr>
+nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab('GoTo')<cr>
 nnoremap <buffer> <leader>pb :GoBuild<cr>
 
 nnoremap <buffer> <leader>ji :GoImports<cr>

--- a/.vim/ftplugin/python.vim
+++ b/.vim/ftplugin/python.vim
@@ -6,11 +6,7 @@ inoremap <buffer> <c-n> <c-x><c-n>
 " the default one doesn't cooperate with vim-jedi for some reason
 inoremap <buffer> <expr><S-Tab> pumvisible()? "\<up>\<C-n>\<C-p>" : "\<c-d>"
 
-nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab("GoToDefinition")<cr>
-nnoremap <buffer> gd :YcmCompleter GoToDefinition<cr>
-nnoremap <buffer> K :YcmCompleter GetDoc<cr>
-nnoremap <buffer> <leader>jr :call dhleong#refactor#Rename()<cr>
-nnoremap <buffer> <leader>js :YcmCompleter GoToReferences<cr>
+call dhleong#completer().MapNavigation()
 
 let b:latte_python_exe = 'python3'
 

--- a/.vim/ftplugin/rust.vim
+++ b/.vim/ftplugin/rust.vim
@@ -1,10 +1,6 @@
 " ======= mappings ========================================
 
-nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab("GoToDefinition")<cr>
-nnoremap <buffer> gd :YcmCompleter GoToDefinition<cr>
-nnoremap <buffer> K :YcmCompleter GetDoc<cr>
-nnoremap <buffer> <leader>jr :call dhleong#refactor#Rename()<cr>
-nnoremap <buffer> <leader>js :YcmCompleter GoToReferences<cr>
+call dhleong#completer().MapNavigation()
 
 " ======= Plugin config ===================================
 

--- a/.vim/ftplugin/swift.vim
+++ b/.vim/ftplugin/swift.vim
@@ -133,10 +133,7 @@ endfunc " }}}
 " ======= mappings ========================================
 
 " my standard mappings
-nnoremap <buffer> <c-w>gd :call dhleong#GotoInNewTab("GoToDefinition")<cr>
-nnoremap <buffer> gd :YcmCompleter GoToDefinition<cr>
-nnoremap <buffer> K :YcmCompleter GetHover<cr>
-nnoremap <buffer> <leader>js :YcmCompleter GoToReferences<cr>
+call dhleong#completer().MapNavigation()
 
 " swift/xcode-specific
 nnoremap <silent> <leader>pr :call <SID>Run()<cr>

--- a/.vim/init/coc.vim
+++ b/.vim/init/coc.vim
@@ -1,0 +1,18 @@
+let g:coc_global_extensions = [
+    \ 'coc-elixir',
+    \ 'coc-go',
+    \ 'coc-jedi',
+    \ 'coc-json',
+    \ 'coc-omnisharp',
+    \ 'coc-prettier',
+    \ 'coc-rust-analyzer',
+    \ 'coc-snippets',
+    \ 'coc-sourcekit',
+    \ 'coc-tsserver',
+    \ 'coc-vimlsp',
+    \ ]
+
+inoremap <silent><expr> <tab> pumvisible() ? "\<c-n>" : "\<tab>"
+inoremap <silent><expr> <s-tab> pumvisible() ? "\<c-p>" : "\<c-d>"
+
+inoremap <silent><expr> <c-space> coc#refresh()

--- a/.vim/init/coc.vim
+++ b/.vim/init/coc.vim
@@ -16,3 +16,13 @@ inoremap <silent><expr> <tab> pumvisible() ? "\<c-n>" : "\<tab>"
 inoremap <silent><expr> <s-tab> pumvisible() ? "\<c-p>" : "\<c-d>"
 
 inoremap <silent><expr> <c-space> coc#refresh()
+
+augroup MyCocActionsGroup
+  autocmd!
+
+  " Setup formatexpr specified filetype(s).
+  autocmd FileType typescript,json setl formatexpr=CocAction('formatSelected')
+
+  " Update signature help on jump placeholder.
+  autocmd User CocJumpPlaceholder call CocActionAsync('showSignatureHelp')
+augroup end

--- a/.vim/init/plugins.vim
+++ b/.vim/init/plugins.vim
@@ -159,30 +159,22 @@ Plug 'tpope/vim-endwise'
 " augmentations, like hyperstyle
 let g:endwise_no_mappings = 1
 
-"" coc.nvim {{{
+"" Completer selection
 
-Plug 'neoclide/coc.nvim', {'branch': 'release'}
+let g:dhleong_completer = 'coc'
 
-let g:coc_global_extensions = [
-    \ 'coc-elixir',
-    \ 'coc-go',
-    \ 'coc-jedi',
-    \ 'coc-json',
-    \ 'coc-omnisharp',
-    \ 'coc-prettier',
-    \ 'coc-rust-analyzer',
-    \ 'coc-snippets',
-    \ 'coc-sourcekit',
-    \ 'coc-tsserver',
-    \ 'coc-vimlsp',
-    \ ]
+if g:dhleong_completer ==# 'coc'
+    Plug 'neoclide/coc.nvim', {'branch': 'release'}
+    source './coc.vim'
+elseif !(has('nvim') || exists('g:neojet#version'))
+    let flags = join(map(s:ycmCompleters, '"--" . v:val . "-completer"'), ' ')
+    Plug 'ycm-core/YouCompleteMe', {'do': './install.py ' . flags}
 
-inoremap <silent><expr> <tab>
-    \ pumvisible() ? "\<C-n>" : "\<tab>"
+    " related, for c/c++ stuff
+    Plug 'rdnetto/YCM-Generator', { 'branch': 'stable'}
 
-inoremap <silent><expr> <c-space> coc#refresh()
-
-"" }}}
+    source './ycm.vim'
+endif
 
 "" Ultisnips
 ""

--- a/.vim/init/plugins.vim
+++ b/.vim/init/plugins.vim
@@ -161,13 +161,14 @@ let g:endwise_no_mappings = 1
 
 "" Completer selection
 
-let g:dhleong_completer = 'coc'
+let g:dhleong_completer = 'ycm'
 
 let s:completer_config_path = resolve(expand('~/.vim/init/' . g:dhleong_completer . '.vim'))
 
 if g:dhleong_completer ==# 'coc'
     Plug 'neoclide/coc.nvim', {'branch': 'release'}
 elseif !(has('nvim') || exists('g:neojet#version'))
+    let s:ycmCompleters = ['clang', 'cs', 'go', 'rust', 'ts']
     let flags = join(map(s:ycmCompleters, '"--" . v:val . "-completer"'), ' ')
     Plug 'ycm-core/YouCompleteMe', {'do': './install.py ' . flags}
 

--- a/.vim/init/plugins.vim
+++ b/.vim/init/plugins.vim
@@ -163,18 +163,19 @@ let g:endwise_no_mappings = 1
 
 let g:dhleong_completer = 'coc'
 
+let s:completer_config_path = resolve(expand('~/.vim/init/' . g:dhleong_completer . '.vim'))
+
 if g:dhleong_completer ==# 'coc'
     Plug 'neoclide/coc.nvim', {'branch': 'release'}
-    source './coc.vim'
 elseif !(has('nvim') || exists('g:neojet#version'))
     let flags = join(map(s:ycmCompleters, '"--" . v:val . "-completer"'), ' ')
     Plug 'ycm-core/YouCompleteMe', {'do': './install.py ' . flags}
 
     " related, for c/c++ stuff
     Plug 'rdnetto/YCM-Generator', { 'branch': 'stable'}
-
-    source './ycm.vim'
 endif
+
+exe 'source ' . s:completer_config_path
 
 "" Ultisnips
 ""

--- a/.vim/init/plugins.vim
+++ b/.vim/init/plugins.vim
@@ -159,94 +159,27 @@ Plug 'tpope/vim-endwise'
 " augmentations, like hyperstyle
 let g:endwise_no_mappings = 1
 
-"" YouCompleteMe
-""
+"" coc.nvim {{{
 
-" YCM LSP {{{
+Plug 'neoclide/coc.nvim', {'branch': 'release'}
 
-let g:ycm_language_server = [
-    \ {
-    \   'name': 'sourcekit-lsp',
-    \   'cmdline': ['xcrun', 'sourcekit-lsp', '--log-level=debug'],
-    \   'filetypes': ['swift'],
-    \   'project_root_files': [ 'Package.swift' ],
-    \ },
-    \ {
-    \   'name': 'elixir-ls',
-    \   'cmdline': [$HOME . '/work/elixir-ls/language_server.sh'],
-    \   'filetypes': ['elixir'],
-    \   'project_root_files': [ 'mix.exs' ],
-    \ }
-    \ ]
-" }}}
-
-let s:ycmCompleters = ['clang', 'cs', 'go', 'rust', 'ts']
-
-if !(has('nvim') || exists('g:neojet#version'))
-    let flags = join(map(s:ycmCompleters, '"--" . v:val . "-completer"'), ' ')
-    Plug 'ycm-core/YouCompleteMe', {'do': './install.py ' . flags}
-
-    " related, for c/c++ stuff
-    Plug 'rdnetto/YCM-Generator', { 'branch': 'stable'}
-endif
-
-" YCM Config {{{
-let g:ycm_filetype_blacklist = {
-    \ 'tagbar' : 1,
-    \ 'qf' : 1,
-    \ 'notes' : 1,
-    \ 'unite' : 1,
-    \ 'vimwiki' : 1,
-    \ 'pandoc' : 1,
-    \}
-
-let g:ycm_filter_diagnostics = {
-    \   'cs': {
-    \     'regex': [
-    \       "Convert to 'return' statement",
-    \       "Convert to '&=' expresssion",
-    \       "Convert to '&=' expression",
-    \       "prefix '_'",
-    \       "Parameter can be ",
-    \       "Redundant argument name specification",
-    \       "Use 'var' keyword",
-    \       "Xml comment",
-    \     ]
-    \   },
-    \   'cpp': {
-    \     'regex': [
-    \       "enumeration in a nested name specifier",
-    \     ]
-    \   }
-    \ }
-
-let g:ycm_key_list_previous_completion = ['<Up>'] " NOT s-tab; we do the right thing below:
-inoremap <expr><S-Tab> pumvisible() ? "\<C-p>" : "\<c-d>"
-
-" most useful for gitcommit
-let g:ycm_collect_identifiers_from_comments_and_strings = 1
-
-let g:ycm_always_populate_location_list = 1
-
-let g:ycm_auto_hover = ''
-
-let g:ycm_tsserver_binary_path = "/Users/dhleong/.npm-packages/bin/tsserver"
-
-" NOTE: use the version installed via homebrew:
-if filereadable('/usr/local/bin/rust-analyzer')
-    let g:ycm_rust_toolchain_root = '/usr/local'
-endif
-
-let g:ycm_extra_conf_globlist = [
-    \ '~/.dotfiles/dots/.vim/bundle/YouCompleteMe/*',
-    \ '~/git/juuce/*',
-    \ '~/git/iaido/*',
-    \ '~/work/*',
+let g:coc_global_extensions = [
+    \ 'coc-elixir',
+    \ 'coc-go',
+    \ 'coc-jedi',
+    \ 'coc-json',
+    \ 'coc-prettier',
+    \ 'coc-rust-analyzer',
+    \ 'coc-snippets',
+    \ 'coc-sourcekit',
+    \ 'coc-tsserver',
+    \ 'coc-vimlsp',
     \ ]
 
-" let g:ycm_max_diagnostics_to_display = 50
-" }}}
+inoremap <silent><expr> <tab>
+    \ pumvisible() ? "\<C-n>" : "\<tab>"
 
+"" }}}
 
 "" Ultisnips
 ""

--- a/.vim/init/plugins.vim
+++ b/.vim/init/plugins.vim
@@ -168,6 +168,7 @@ let g:coc_global_extensions = [
     \ 'coc-go',
     \ 'coc-jedi',
     \ 'coc-json',
+    \ 'coc-omnisharp',
     \ 'coc-prettier',
     \ 'coc-rust-analyzer',
     \ 'coc-snippets',
@@ -178,6 +179,8 @@ let g:coc_global_extensions = [
 
 inoremap <silent><expr> <tab>
     \ pumvisible() ? "\<C-n>" : "\<tab>"
+
+inoremap <silent><expr> <c-space> coc#refresh()
 
 "" }}}
 

--- a/.vim/init/ycm.vim
+++ b/.vim/init/ycm.vim
@@ -1,0 +1,75 @@
+" YCM LSP {{{
+
+let g:ycm_language_server = [
+    \ {
+    \   'name': 'sourcekit-lsp',
+    \   'cmdline': ['xcrun', 'sourcekit-lsp', '--log-level=debug'],
+    \   'filetypes': ['swift'],
+    \   'project_root_files': [ 'Package.swift' ],
+    \ },
+    \ {
+    \   'name': 'elixir-ls',
+    \   'cmdline': [$HOME . '/work/elixir-ls/language_server.sh'],
+    \   'filetypes': ['elixir'],
+    \   'project_root_files': [ 'mix.exs' ],
+    \ }
+    \ ]
+" }}}
+
+let s:ycmCompleters = ['clang', 'cs', 'go', 'rust', 'ts']
+
+let g:ycm_filetype_blacklist = {
+    \ 'tagbar' : 1,
+    \ 'qf' : 1,
+    \ 'notes' : 1,
+    \ 'unite' : 1,
+    \ 'vimwiki' : 1,
+    \ 'pandoc' : 1,
+    \}
+
+let g:ycm_filter_diagnostics = {
+    \   'cs': {
+    \     'regex': [
+    \       "Convert to 'return' statement",
+    \       "Convert to '&=' expresssion",
+    \       "Convert to '&=' expression",
+    \       "prefix '_'",
+    \       "Parameter can be ",
+    \       "Redundant argument name specification",
+    \       "Use 'var' keyword",
+    \       "Xml comment",
+    \     ]
+    \   },
+    \   'cpp': {
+    \     'regex': [
+    \       "enumeration in a nested name specifier",
+    \     ]
+    \   }
+    \ }
+
+let g:ycm_key_list_previous_completion = ['<Up>'] " NOT s-tab; we do the right thing below:
+inoremap <expr><S-Tab> pumvisible() ? "\<C-p>" : "\<c-d>"
+
+" most useful for gitcommit
+let g:ycm_collect_identifiers_from_comments_and_strings = 1
+
+let g:ycm_always_populate_location_list = 1
+
+let g:ycm_auto_hover = ''
+
+let g:ycm_tsserver_binary_path = "/Users/dhleong/.npm-packages/bin/tsserver"
+
+" NOTE: use the version installed via homebrew:
+if filereadable('/usr/local/bin/rust-analyzer')
+    let g:ycm_rust_toolchain_root = '/usr/local'
+endif
+
+let g:ycm_extra_conf_globlist = [
+    \ '~/.dotfiles/dots/.vim/bundle/YouCompleteMe/*',
+    \ '~/git/juuce/*',
+    \ '~/git/iaido/*',
+    \ '~/work/*',
+    \ ]
+
+" let g:ycm_max_diagnostics_to_display = 50
+

--- a/.vim/init/ycm.vim
+++ b/.vim/init/ycm.vim
@@ -16,8 +16,6 @@ let g:ycm_language_server = [
     \ ]
 " }}}
 
-let s:ycmCompleters = ['clang', 'cs', 'go', 'rust', 'ts']
-
 let g:ycm_filetype_blacklist = {
     \ 'tagbar' : 1,
     \ 'qf' : 1,


### PR DESCRIPTION
So far I've just switched back to YCM from COC because it's just not super reliable, but the refactor to pull out YCM-specific stuff seems worthwhile.

- Begin experimenting with COC for completion... take 2
- Improve diagnostic navigation with coc
- coc: Use <c-space> to trigger completion
- Begin abstracting out completer-provided-functionality access
- Migrate rename refactor action + add some coc settings
- Unify navigation mappings into the completer (mostly)
- Unify new tab navigation mappings/handling
- Fix completer config loading
- Experiment with enabling "trigger" keys to also confirm completion
- Tweak coc-settings
- Fix ycm init
